### PR TITLE
adjust action parameters based on original tailscale/github-action

### DIFF
--- a/.github/workflows/speed-comparison.yml
+++ b/.github/workflows/speed-comparison.yml
@@ -71,7 +71,7 @@ jobs:
         uses: ./
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: "tag:ci"
           version: "1.82.0"
           use-cache: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
         uses: ./
         with:
           oauth-client-id: ${{ secrets.TS_AUTH_KEYS_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TS_AUTH_KEYS_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TS_AUTH_KEYS_OAUTH_CLIENT_SECRET }}
           tags: "tag:ci"
           version: "${{ matrix.version }}"
           use-cache: false

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This action is written in Typescript using official GitHub SDKs. It provides som
   uses: jaxxstorm/action-setup-tailscale@v1
   with:
     oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-    oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+    oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
     tags: "ci,github-actions"
     version: latest
 ```
@@ -53,7 +53,7 @@ This action is written in Typescript using official GitHub SDKs. It provides som
   uses: jaxxstorm/action-setup-tailscale@v1
   with:
     oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-    oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+    oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
     tags: "ci,github-actions,deploy"
     version: "1.82.0"
     hostname: "ci-${{ github.run_id }}"
@@ -69,7 +69,7 @@ This action is written in Typescript using official GitHub SDKs. It provides som
 |-------|-------------|----------|---------|
 | `authkey` | Tailscale authentication key | false | |
 | `oauth-client-id` | OAuth Client ID | false | |
-| `oauth-client-secret` | OAuth Client Secret | false | |
+| `oauth-secret` | OAuth Client Secret | false | |
 | `tags` | Comma-separated list of tags | false | |
 | `version` | Tailscale version to install | true | `1.82.0` |
 | `hostname` | Custom hostname | false | `github-<runner-name>` |
@@ -152,7 +152,7 @@ jobs:
         uses: jaxxstorm/action-setup-tailscale@v1
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: "ci,deploy"
           use-cache: true
       
@@ -180,7 +180,7 @@ jobs:
         uses: jaxxstorm/action-setup-tailscale@v1
         with:
           oauth-client-id: ${{ secrets.TAILSCALE_OAUTH_CLIENT_ID }}
-          oauth-client-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
+          oauth-secret: ${{ secrets.TAILSCALE_OAUTH_CLIENT_SECRET }}
           tags: "ci,test"
           hostname: "test-${{ matrix.os }}-${{ github.run_id }}"
           use-cache: true

--- a/action.yml
+++ b/action.yml
@@ -12,15 +12,16 @@ inputs:
   oauth-client-id:
     description: 'Your Tailscale OAuth Client ID.'
     required: false
-  oauth-client-secret:
+  oauth-secret:
     description: 'Your Tailscale OAuth Client Secret.'
     required: false
   tags:
-    description: 'Comma separated list of tags to be applied to nodes (OAuth client must have permission to apply these tags).'
+    description: 'Comma separated list of Tags to be applied to nodes. The OAuth client must have permission to apply these tags.'
     required: false
   version:
-    description: 'Tailscale version to use. Specify `latest` for the latest stable version.'
+    description: 'Tailscale version to use. Specify `latest` to use the latest stable version, and `unstable` to use the latest development version.'
     required: true
+    default: '1.88.3'
   args:
     description: 'Optional additional arguments to `tailscale up`.'
     required: false
@@ -30,7 +31,7 @@ inputs:
     required: false
     default: ''
   hostname:
-    description: 'Fixed hostname to use.'
+    description: 'Fixed hostname to use. Must be a valid DNS label (alphanumeric and dashes only, 1-63 characters, cannot start or end with a dash). If not provided, a hostname will be generated based on the runner name.'
     required: false
     default: ''
   timeout:
@@ -38,7 +39,7 @@ inputs:
     required: false
     default: '2m'
   retry:
-    description: 'Number of retry attempts for Tailscale connection.'
+    description: 'Number of retries for `tailscale up`.'
     required: false
     default: '5'
   use-cache:
@@ -50,7 +51,7 @@ inputs:
     required: false
     default: ''
   sha256sum:
-    description: 'Expected SHA256 checksum of the Tailscale package. If not provided, it will be fetched automatically.'
+    description: 'Expected SHA256 checksum of the tarball.'
     required: false
     default: ''
   ping:

--- a/dist/index.js
+++ b/dist/index.js
@@ -41299,7 +41299,7 @@ async function getInputs() {
         arch: "",
         authKey: core.getInput("authkey") || "",
         oauthClientId: core.getInput("oauth-client-id") || "",
-        oauthSecret: core.getInput("oauth-client-secret") || "",
+        oauthSecret: core.getInput("oauth-secret") || "",
         tags: core.getInput("tags") || "",
         hostname: core.getInput("hostname") || "",
         args: core.getInput("args") || "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -233,7 +233,7 @@ async function getInputs(): Promise<TailscaleConfig> {
     arch: "",
     authKey: core.getInput("authkey") || "",
     oauthClientId: core.getInput("oauth-client-id") || "",
-    oauthSecret: core.getInput("oauth-client-secret") || "",
+    oauthSecret: core.getInput("oauth-secret") || "",
     tags: core.getInput("tags") || "",
     hostname: core.getInput("hostname") || "",
     args: core.getInput("args") || "",


### PR DESCRIPTION
…github-action

`oauth-client-secret` is renamed to `oauth-secret` to match the original action.

Not all of the descriptions matched exactly, but this attempts to take the best from both versions.

Default Tailscale version is updated to 1.88.3.

Updates tailscale/corp#32814